### PR TITLE
ebs-nvme-mapping.sh: in some case $mapping is already beginning with /dev

### DIFF
--- a/files/ebs-nvme-mapping.sh
+++ b/files/ebs-nvme-mapping.sh
@@ -7,7 +7,10 @@ for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
 
   if [[ "${mapping}" == "" ]]; then
     ( test -b "${blkdev}" && test -L "/dev/local0" ) || ln -s "${blkdev}" "/dev/local0"
-  elif [[ "/dev/${mapping}" == /dev/* ]]; then
-    ( test -b "${blkdev}" && test -L "/dev/${mapping}" ) || ln -s "${blkdev}" "/dev/${mapping}"
+  else
+    if [[ "${mapping}" != /dev/* ]]; then
+        mapping="/dev/${mapping}"
+    fi
+    ( test -b "${blkdev}" && test -L "${mapping}" ) || ln -s "${blkdev}" "${mapping}"
   fi
 done


### PR DESCRIPTION
Current working case with external-worker:
```
$ nvme list | awk '/^\/dev/ { print $1 }'
/dev/nvme0n1
/dev/nvme1n1
/dev/nvme2n1

$ nvme id-ctrl --raw-binary "/dev/nvme0n1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g'
xvda

$ nvme id-ctrl --raw-binary "/dev/nvme1n1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g'
xvdf

$ nvme id-ctrl --raw-binary "/dev/nvme2n1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g'

```

But in another case for a customer:
```
$ nvme list | awk '/^\/dev/ { print $1 }'
/dev/nvme0n1
/dev/nvme1n1

$ nvme id-ctrl --raw-binary "/dev/nvme0n1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g'
xvda

$ nvme id-ctrl --raw-binary "/dev/nvme1n1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g'
/dev/xvdf
```

Which is making the script to fail:
```
$ /usr/local/bin/ebs-nvme-mapping
ln: failed to create symbolic link '/dev//dev/xvdf': No such file or directory
```